### PR TITLE
Do not auto-accept while the player has a resurrect delay

### DIFF
--- a/AutoAcceptRes/AutoAcceptRes.lua
+++ b/AutoAcceptRes/AutoAcceptRes.lua
@@ -75,10 +75,15 @@ frame:SetScript("OnEvent", function(self, event, ...)
 	end
 		
 	if event == "RESURRECT_REQUEST" then
-		playerName = ...
+		local playerName = ...
 		
 		if AAR_ENABLED ~= 1 then return end
 		
+		if GetCorpseRecoveryDelay() > 0 then
+			print("Could not auto-accept res because you are on resurrect delay.")
+			return
+		end
+
 		if AAR_ACCEPT_IN_COMBAT == 1 then
 			AcceptResurrect()
 		elseif UnitInParty(playerName) or UnitInRaid(playerName) ~= nil then


### PR DESCRIPTION
If a player dies repeatedly, they will be unable to resurrect for some time.

When they receive a resurrection during this time (with `GetCorpseRecoveryDelay() > 0`), AutoAcceptRes currently still calls `AcceptResurrect()`. This results in the player being unable to accept that same resurrection later, when doing so would actually work.

The pull request adds a check for resurrection delay, so it no longer does this. This makes manually accepting the delayed resurrection work.

## How to reproduce issue
1. Die (repeatedly) until you are unable to resurrect immediately.
2. Have a player try to resurrect you.
3. AutoRes will try to auto-accept this resurrection.
4. Once the resurrect delay timer expires, try to accept the resurrection manually.

#### Bugged (current upstream) behavior
5. The resurrect popup disappears, but the player remains dead.

#### Fixed (this PR) behavior
5. The resurrection is accepted, and the player revives.